### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -12,6 +12,7 @@ on configure => sub {
 on test => sub {
     requires 'DBI';
     requires 'Test::Git';
+    requires 'Test::Requires::Git', '1.005';
     requires 'Test::More', '0.98';
     requires 'Test::Requires';
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Git;
+use Test::Requires::Git;
 
 use File::Spec;
 use File::Path 'make_path';
@@ -13,7 +14,7 @@ if ($@) {
     plan skip_all => 'DBD::SQLite is required to run this test';
 }
 
-has_git;
+test_requires_git;
 
 use_ok 'GitDDL::Migrator';
 

--- a/t/mysqld.t
+++ b/t/mysqld.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Git;
+use Test::Requires::Git;
 
 use File::Spec;
 use File::Path 'make_path';
@@ -9,7 +10,7 @@ use DBI;
 use Time::HiRes;
 use Test::Requires 'Test::mysqld';
 
-has_git;
+test_requires_git;
 
 use_ok 'GitDDL::Migrator';
 


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.